### PR TITLE
Implement Steam OTP

### DIFF
--- a/AuthenticatorPro.Shared/AuthenticatorPro.Shared.csproj
+++ b/AuthenticatorPro.Shared/AuthenticatorPro.Shared.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Source\Data\Generator\Hotp.cs" />
     <Compile Include="Source\Data\Generator\IGenerator.cs" />
     <Compile Include="Source\Data\Generator\MobileOtp.cs" />
+    <Compile Include="Source\Data\Generator\SteamOtp.cs" />
     <Compile Include="Source\Data\Generator\Totp.cs" />
     <Compile Include="Source\Data\ISource.cs" />
     <Compile Include="Source\Query\WearCategory.cs" />

--- a/AuthenticatorPro.Shared/Source/Data/AuthenticatorType.cs
+++ b/AuthenticatorPro.Shared/Source/Data/AuthenticatorType.cs
@@ -5,7 +5,7 @@ namespace AuthenticatorPro.Shared.Data
 {
     public enum AuthenticatorType
     {
-        Hotp = 1, Totp = 2, MobileOtp = 3
+        Hotp = 1, Totp = 2, MobileOtp = 3, SteamOtp = 4
     }
 
     public static class AuthenticatorTypeSpecification
@@ -17,6 +17,7 @@ namespace AuthenticatorPro.Shared.Data
                 AuthenticatorType.Hotp => GenerationMethod.Counter,
                 AuthenticatorType.Totp => GenerationMethod.Time,
                 AuthenticatorType.MobileOtp => GenerationMethod.Time,
+                AuthenticatorType.SteamOtp => GenerationMethod.Time,
                 _ => throw new ArgumentOutOfRangeException(nameof(type))
             };
         }
@@ -28,6 +29,7 @@ namespace AuthenticatorPro.Shared.Data
                 AuthenticatorType.Hotp => true,
                 AuthenticatorType.Totp => true,
                 AuthenticatorType.MobileOtp => false,
+                AuthenticatorType.SteamOtp => true,
                 _ => throw new ArgumentOutOfRangeException(nameof(type))
             };
         }

--- a/AuthenticatorPro.Shared/Source/Data/Generator/SteamOtp.cs
+++ b/AuthenticatorPro.Shared/Source/Data/Generator/SteamOtp.cs
@@ -6,17 +6,14 @@ namespace AuthenticatorPro.Shared.Data.Generator
 {
     public class SteamOtp : IGenerator
     {
-        public const string Alphabet = "23456789BCDFGHJKMNPQRTVWXY";
-        public const int Digits = 5;
-
         private readonly OtpNet.Totp _totp;
 
         public GenerationMethod GenerationMethod => GenerationMethod.Time;
 
-        public SteamOtp(string secret, int digits)
+        public SteamOtp(string secret)
         {
             var secretBytes = Base32Encoding.ToBytes(secret);
-            _totp = new SteamTotp(secretBytes, digits);
+            _totp = new SteamTotp(secretBytes);
         }
 
         public string Compute()
@@ -30,11 +27,12 @@ namespace AuthenticatorPro.Shared.Data.Generator
 
         private class SteamTotp : OtpNet.Totp
         {
-            private readonly int _digits;
+            public const int NumDigits = 5;
 
-            public SteamTotp(byte[] secretKey, int digits = 5) : base(secretKey, 30, OtpHashMode.Sha1, digits)
+            private const string Alphabet = "23456789BCDFGHJKMNPQRTVWXY";
+
+            public SteamTotp(byte[] secretKey) : base(secretKey, 30, OtpHashMode.Sha1, NumDigits)
             {
-                _digits = digits;
             }
 
             protected override string Compute(long counter, OtpHashMode mode)
@@ -46,7 +44,7 @@ namespace AuthenticatorPro.Shared.Data.Generator
 
                 var builder = new StringBuilder();
 
-                for (int i = 0; i < _digits; i++) {
+                for (var i = 0; i < NumDigits; i++) {
                     builder.Append(Alphabet[otp % Alphabet.Length]);
                     otp /= Alphabet.Length;
                 }

--- a/AuthenticatorPro.Shared/Source/Data/Generator/SteamOtp.cs
+++ b/AuthenticatorPro.Shared/Source/Data/Generator/SteamOtp.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Text;
+using OtpNet;
+
+namespace AuthenticatorPro.Shared.Data.Generator
+{
+    public class SteamOtp : IGenerator
+    {
+        public const string Alphabet = "23456789BCDFGHJKMNPQRTVWXY";
+        public const int Digits = 5;
+
+        private readonly OtpNet.Totp _totp;
+
+        public GenerationMethod GenerationMethod => GenerationMethod.Time;
+
+        public SteamOtp(string secret, int digits)
+        {
+            var secretBytes = Base32Encoding.ToBytes(secret);
+            _totp = new SteamTotp(secretBytes, digits);
+        }
+
+        public string Compute()
+        {
+            return _totp.ComputeTotp();
+        }
+
+        public DateTime GetRenewTime() {
+            return DateTime.UtcNow.AddSeconds(_totp.RemainingSeconds());
+        }
+
+        private class SteamTotp : OtpNet.Totp
+        {
+            private readonly int _digits;
+
+            public SteamTotp(byte[] secretKey, int digits = 5) : base(secretKey, 30, OtpHashMode.Sha1, digits)
+            {
+                _digits = digits;
+            }
+
+            protected override string Compute(long counter, OtpHashMode mode)
+            {
+                // As base.Compute(long, OtpHashMode), but doesn't call Digits(long, int)
+                var data = BitConverter.GetBytes(counter);
+                Array.Reverse(data);
+                var otp = (int) CalculateOtp(data, mode);
+
+                var builder = new StringBuilder();
+
+                for (int i = 0; i < _digits; i++) {
+                    builder.Append(Alphabet[otp % Alphabet.Length]);
+                    otp /= Alphabet.Length;
+                }
+
+                return builder.ToString();
+            }
+        }
+    }
+}

--- a/AuthenticatorPro.WearOS/Source/Activity/CodeActivity.cs
+++ b/AuthenticatorPro.WearOS/Source/Activity/CodeActivity.cs
@@ -67,7 +67,7 @@ namespace AuthenticatorPro.WearOS.Activity
             _generator = type switch
             {
                 AuthenticatorType.MobileOtp => new MobileOtp(secret, _digits, _period),
-                AuthenticatorType.SteamOtp => new SteamOtp(secret, _digits),
+                AuthenticatorType.SteamOtp => new SteamOtp(secret),
                 _ => new Totp(secret, _period, algorithm, _digits),
             };
 

--- a/AuthenticatorPro.WearOS/Source/Activity/CodeActivity.cs
+++ b/AuthenticatorPro.WearOS/Source/Activity/CodeActivity.cs
@@ -10,6 +10,7 @@ using AndroidX.AppCompat.App;
 using AuthenticatorPro.Shared.Data;
 using AuthenticatorPro.Shared.Data.Generator;
 using OtpNet;
+using SteamOtp = AuthenticatorPro.Shared.Data.Generator.SteamOtp;
 using Totp = AuthenticatorPro.Shared.Data.Generator.Totp;
 
 namespace AuthenticatorPro.WearOS.Activity
@@ -66,6 +67,7 @@ namespace AuthenticatorPro.WearOS.Activity
             _generator = type switch
             {
                 AuthenticatorType.MobileOtp => new MobileOtp(secret, _digits, _period),
+                AuthenticatorType.SteamOtp => new SteamOtp(secret, _digits),
                 _ => new Totp(secret, _period, algorithm, _digits),
             };
 

--- a/AuthenticatorPro/Resources/values/arrays.xml
+++ b/AuthenticatorPro/Resources/values/arrays.xml
@@ -4,6 +4,7 @@
         <item>@string/authTypeTime</item>
         <item>@string/authTypeCounter</item>
         <item>@string/authTypeMobileOtp</item>
+        <item>@string/authTypeSteam</item>
     </string-array>
     <string-array name="authAlgorithms">
         <item>@string/authAlgorithmSHA1</item>

--- a/AuthenticatorPro/Resources/values/strings.xml
+++ b/AuthenticatorPro/Resources/values/strings.xml
@@ -152,6 +152,7 @@
     <string name="authTypeTime">Time Based (TOTP)</string>
     <string name="authTypeCounter">Counter Based (HOTP)</string>
     <string name="authTypeMobileOtp">Mobile-OTP (mOTP)</string>
+    <string name="authTypeSteam">Steam</string>
     <string name="authAlgorithmSHA1">SHA1 (default)</string>
     <string name="authAlgorithmSHA256">SHA256</string>
     <string name="authAlgorithmSHA512">SHA512</string>

--- a/AuthenticatorPro/Source/Data/Authenticator.cs
+++ b/AuthenticatorPro/Source/Data/Authenticator.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using OtpNet;
 using SQLite;
 using Hotp = AuthenticatorPro.Shared.Data.Generator.Hotp;
+using SteamOtp = AuthenticatorPro.Shared.Data.Generator.SteamOtp;
 using Totp = AuthenticatorPro.Shared.Data.Generator.Totp;
 
 namespace AuthenticatorPro.Data
@@ -23,7 +24,7 @@ namespace AuthenticatorPro.Data
         public const int DefaultDigits = 6;
         public const int DefaultPeriod = 30;
 
-        public const int MinDigits = 6;
+        public const int MinDigits = 5;
         public const int MaxDigits = 10;
 
 
@@ -88,6 +89,7 @@ namespace AuthenticatorPro.Data
                 AuthenticatorType.Totp => new Totp(Secret, Period, Algorithm, Digits),
                 AuthenticatorType.Hotp => new Hotp(Secret, Algorithm, Digits, Counter),
                 AuthenticatorType.MobileOtp => new MobileOtp(Secret, Digits, Period),
+                AuthenticatorType.SteamOtp => new SteamOtp(Secret, Digits),
                 _ => throw new ArgumentException("Unknown authenticator type.")
             };
             
@@ -314,7 +316,7 @@ namespace AuthenticatorPro.Data
 
         public static string CleanSecret(string input, AuthenticatorType type)
         {
-            if(type == AuthenticatorType.Totp || type == AuthenticatorType.Hotp)
+            if(type == AuthenticatorType.Totp || type == AuthenticatorType.Hotp || type == AuthenticatorType.SteamOtp)
                 input = input.ToUpper();
             
             input = input.Replace(" ", "");
@@ -332,6 +334,7 @@ namespace AuthenticatorPro.Data
             {
                 case AuthenticatorType.Totp:
                 case AuthenticatorType.Hotp:
+                case AuthenticatorType.SteamOtp:
                     try
                     {
                         return Base32Encoding.ToBytes(secret).Length > 0;

--- a/AuthenticatorPro/Source/Fragment/AddAuthenticatorBottomSheet.cs
+++ b/AuthenticatorPro/Source/Fragment/AddAuthenticatorBottomSheet.cs
@@ -215,12 +215,7 @@ namespace AuthenticatorPro.Fragment
                 isValid = false;
             }
 
-            int digits;
-            if(_type == AuthenticatorType.SteamOtp)
-            {
-                digits = SteamOtp.Digits;
-            }
-            else if(!Int32.TryParse(_digitsText.Text, out digits) || digits < Authenticator.MinDigits || digits > Authenticator.MaxDigits)
+            if(!Int32.TryParse(_digitsText.Text, out var digits) || digits < Authenticator.MinDigits || digits > Authenticator.MaxDigits)
             {
                 _digitsLayout.Error = GetString(Resource.String.digitsInvalid);
                 isValid = false;

--- a/AuthenticatorPro/Source/Fragment/AddAuthenticatorBottomSheet.cs
+++ b/AuthenticatorPro/Source/Fragment/AddAuthenticatorBottomSheet.cs
@@ -128,6 +128,7 @@ namespace AuthenticatorPro.Fragment
             _type = e.Position switch {
                 1 => AuthenticatorType.Hotp,
                 2 => AuthenticatorType.MobileOtp,
+                3 => AuthenticatorType.SteamOtp,
                 _ => AuthenticatorType.Totp,
             };
 
@@ -135,11 +136,15 @@ namespace AuthenticatorPro.Fragment
                 ? ViewStates.Visible
                 : ViewStates.Invisible;
 
-            _algorithmLayout.Visibility = _type.IsHmacBased()
+            _algorithmLayout.Visibility = _type.IsHmacBased() && _type != AuthenticatorType.SteamOtp
                 ? ViewStates.Visible
                 : ViewStates.Gone;
 
             _pinLayout.Visibility = _type == AuthenticatorType.MobileOtp
+                ? ViewStates.Visible
+                : ViewStates.Gone;
+
+            _digitsLayout.Visibility = _type != AuthenticatorType.SteamOtp
                 ? ViewStates.Visible
                 : ViewStates.Gone;
         }
@@ -210,7 +215,12 @@ namespace AuthenticatorPro.Fragment
                 isValid = false;
             }
 
-            if(!Int32.TryParse(_digitsText.Text, out var digits) || digits < Authenticator.MinDigits || digits > Authenticator.MaxDigits)
+            int digits;
+            if(_type == AuthenticatorType.SteamOtp)
+            {
+                digits = SteamOtp.Digits;
+            }
+            else if(!Int32.TryParse(_digitsText.Text, out digits) || digits < Authenticator.MinDigits || digits > Authenticator.MaxDigits)
             {
                 _digitsLayout.Error = GetString(Resource.String.digitsInvalid);
                 isValid = false;


### PR DESCRIPTION
Steam uses a 5-character TOTP implementation rather than an X-digit format. The implementation is well-known across other OTP apps.

In terms of the code, I've never touched C# before and have used Android only briefly, but work with Java professionally.

- Otp.NET's TOTP implementation doesn't expose the raw generated OTP before it's returned as a string (internal method), so I've subclassed it to get access to it and format the OTP as required. I don't know the typical (or your preferred) style for internal, one-off helper classes, so please advise.
- I've adjusted the UI and checks to allow for a 5-digit code, but I'm not particularly happy with it, nor with the alternative of adding hard checks against `SteamOtp` every time we check the digit count. Thoughts?
- Given that the Steam format has a hard-coded algorithm and digits, the advanced settings probably shouldn't be shown, but I'm not sure the best way to do so.
- I've not added any particular support for adding it from a URI; should I?

The implementation otherwise is functional based on me comparing between this version and two known working implementations (andOTP, Bitwarden) for ten minutes or so.