### PR TITLE
Updated name of Polish language

### DIFF
--- a/AuthenticatorPro.Droid/Resources/values/strings.xml
+++ b/AuthenticatorPro.Droid/Resources/values/strings.xml
@@ -324,7 +324,7 @@
     <string name="french" translatable="false">Français</string>
     <string name="italian" translatable="false">Italiano</string>
     <string name="dutch" translatable="false">Nederlands</string>
-    <string name="polish" translatable="false">Polskie</string>
+    <string name="polish" translatable="false">Polski</string>
     <string name="brazilianPortuguese" translatable="false">Portugues do Brasil</string>
     <string name="russian" translatable="false">Pусский</string>
     <string name="slovak" translatable="false">Slovensky</string>


### PR DESCRIPTION
Polskie means that sth is from Poland, so this PR fixes that.