### PR TITLE
fix(translation): German tranlsation name

### DIFF
--- a/AuthenticatorPro.Droid/Resources/values/strings.xml
+++ b/AuthenticatorPro.Droid/Resources/values/strings.xml
@@ -356,7 +356,7 @@
     <string name="four">4</string>
 
     <!-- Arrays > Languages -->
-    <string name="german" translatable="false">Deutsche</string>
+    <string name="german" translatable="false">Deutsch</string>
     <string name="english" translatable="false">English</string>
     <string name="spanish" translatable="false">Español</string>
     <string name="esperanto" translatable="false">Esperanto</string>


### PR DESCRIPTION
Fixes an issue with the name for the German translation name, it was falsely translated as the name of German people, not the name of the language.