### PR TITLE
feat: Add compatibility for Android 4.0.3 (API 15)

### DIFF
--- a/Stratum.Droid/Properties/AndroidManifest.xml
+++ b/Stratum.Droid/Properties/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
           android:versionName="1.3.0"
           package="com.stratumauth.app" android:installLocation="auto" android:versionCode="11">
-    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="36"/>
+    <uses-sdk android:minSdkVersion="15" android:targetSdkVersion="36"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <uses-permission android:name="android.permission.FLASHLIGHT"/>

--- a/Stratum.Droid/Stratum.Droid.csproj
+++ b/Stratum.Droid/Stratum.Droid.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net9.0-android36.0</TargetFramework>
-        <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion>15</SupportedOSPlatformVersion>
         <OutputType>Exe</OutputType>
         <Nullable>disable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>

--- a/Stratum.Droid/src/Activity/ScanActivity.cs
+++ b/Stratum.Droid/src/Activity/ScanActivity.cs
@@ -33,6 +33,13 @@ namespace Stratum.Droid.Activity
         {
             base.OnCreate(savedInstanceState);
 
+            if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
+            {
+                Toast.MakeText(this, "Camera is not supported on this version of Android.", ToastLength.Long).Show();
+                Finish();
+                return;
+            }
+
             _previewView = FindViewById<PreviewView>(Resource.Id.previewView);
             _previewView.Touch += OnPreviewViewTouch;
 

--- a/Stratum.Droid/src/Activity/SettingsActivity.cs
+++ b/Stratum.Droid/src/Activity/SettingsActivity.cs
@@ -282,6 +282,10 @@ namespace Stratum.Droid.Activity
 
         private bool CanUseBiometrics()
         {
+            if (Build.VERSION.SdkInt < BuildVersionCodes.M)
+            {
+                return false;
+            }
             var biometricManager = BiometricManager.From(this);
             return biometricManager.CanAuthenticate(BiometricManager.Authenticators.BiometricStrong) ==
                    BiometricManager.BiometricSuccess;
@@ -306,6 +310,11 @@ namespace Stratum.Droid.Activity
 
         private void EnableBiometrics(Action<bool> callback)
         {
+            if (Build.VERSION.SdkInt < BuildVersionCodes.M)
+            {
+                callback(false);
+                return;
+            }
             var passwordStorage = new BiometricStorage(this);
             var executor = ContextCompat.GetMainExecutor(this);
             var authCallback = new AuthenticationCallback();

--- a/Stratum.Droid/src/Interface/Fragment/UnlockBottomSheet.cs
+++ b/Stratum.Droid/src/Interface/Fragment/UnlockBottomSheet.cs
@@ -86,7 +86,8 @@ namespace Stratum.Droid.Interface.Fragment
             
             _useBiometricsButton = view.FindViewById<MaterialButton>(Resource.Id.buttonUseBiometrics);
 
-            if (_preferences.AllowBiometrics)
+            // Biometric support is only available on Android 6.0 (API 23) and above.
+            if (_preferences.AllowBiometrics && Build.VERSION.SdkInt >= BuildVersionCodes.M)
             {
                 var biometricManager = BiometricManager.From(RequireContext());
                 _canUseBiometrics = biometricManager.CanAuthenticate(BiometricManager.Authenticators.BiometricStrong) ==
@@ -152,6 +153,12 @@ namespace Stratum.Droid.Interface.Fragment
 
         private void ShowBiometricPrompt()
         {
+            // Biometric prompt is not supported on versions below Android 6.0 (API 23).
+            if (Build.VERSION.SdkInt < BuildVersionCodes.M)
+            {
+                return;
+            }
+
             var executor = ContextCompat.GetMainExecutor(RequireContext());
             var passwordStorage = new BiometricStorage(Context);
             var callback = new AuthenticationCallback();

--- a/Stratum.Droid/src/Storage/BiometricStorage.cs
+++ b/Stratum.Droid/src/Storage/BiometricStorage.cs
@@ -33,6 +33,12 @@ namespace Stratum.Droid.Storage
 
         private static void GenerateKey()
         {
+            if (Build.VERSION.SdkInt < BuildVersionCodes.M)
+            {
+                // KeyGenParameterSpec.Builder is not available on API < 23
+                throw new NotSupportedException("Biometric authentication is not supported on this API level.");
+            }
+
 #pragma warning disable CA1416
             var specBuilder =
                 new KeyGenParameterSpec.Builder(KeyAlias, KeyStorePurpose.Encrypt | KeyStorePurpose.Decrypt)


### PR DESCRIPTION
This commit introduces changes to make the application compatible with Android 4.0.3 and later versions.

- The minimum SDK version has been lowered to 15 in the AndroidManifest.xml and the project file.
- Version checks have been added to the code to handle APIs that are not available on older Android versions.
- The camera-based QR code scanning feature is now disabled on devices running Android versions older than 5.0 (API 21).
- The biometric unlock feature is disabled on devices running Android versions older than 6.0 (API 23).